### PR TITLE
O2 f 707 frontend /feat/delete invalidate coupon

### DIFF
--- a/src/apis/coupon/CouponClient.ts
+++ b/src/apis/coupon/CouponClient.ts
@@ -15,6 +15,14 @@ export const updateCouponInfo = async (couponInfoId:number | undefined, body: Co
   return await authAxiosInstance.patch(COUPON_ADMIN_PREFIX + COUPON_PREFIX + `/${couponInfoId}`, body)
 }
 
+export const deleteCouponInfo = async (couponInfoId:number): Promise<AxiosResponse> => {
+  return await authAxiosInstance.delete(COUPON_ADMIN_PREFIX + COUPON_PREFIX + `/${couponInfoId}`)
+}
+
+export const invalidateCouponInfo = async (couponInfoId:number): Promise<AxiosResponse> => {
+  return await authAxiosInstance.patch(COUPON_ADMIN_PREFIX + COUPON_PREFIX + `/${couponInfoId}/invalidate`)
+}
+
 export const getCouponInfoPage = async (size?: number, page?: number): Promise<CouponInfoPageResponse> => {
   let queryParams: string[] = [];
   if (size != null) {

--- a/src/assets/css/confirm-dialogue-modal.css
+++ b/src/assets/css/confirm-dialogue-modal.css
@@ -1,0 +1,72 @@
+.modal {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 1000;
+    background-color: rgba(0, 0, 0, 0.5);
+  }
+  
+  .modal-content {
+    background-color: #fefefe;
+    margin: auto;
+    padding: 20px;
+    border-radius: 5px;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
+    width: 26%;
+    position: relative;
+    display: flex;
+    flex-direction: column;
+  }
+  
+  .modal-title {
+    font-family: "The Jamsil 4 Medium";
+    font-size: 1.5rem;
+    margin-bottom: 2vh;
+  }
+
+  .modal-message {
+    font-family: "The Jamsil 4 Regular";
+    font-size: 1.2rem;
+    margin-bottom: 1vh;
+  }
+  
+  .modal-confirm-btn {
+    border: none;
+    padding: 10px 20px;
+    font-size: 1.2rem;
+    cursor: pointer;
+    background-color: #C22727;
+    color: white;
+    border-radius: 5px;
+    margin-top: 10px;
+  }
+  
+  .modal-confirm-btn:hover {
+    background-color: #9E1B1B;
+  }
+
+  .modal-cancel-btn {
+    border: none;
+    padding: 10px 20px;
+    font-size: 1.2rem;
+    cursor: pointer;
+    background-color: #808080;
+    color: white;
+    border-radius: 5px;
+    margin-top: 10px;
+  }
+  
+  .modal-cancel-btn:hover {
+    background-color: #666666;
+  }
+  
+  .flex-row {
+    display: flex;
+    justify-content: space-evenly;
+    width: 100%;
+  }

--- a/src/components/common/ConfirmDialogueModal.vue
+++ b/src/components/common/ConfirmDialogueModal.vue
@@ -1,0 +1,42 @@
+<template>
+  <div class="modal" v-if="isVisible">
+    <div class="modal-content">
+      <h2 class="modal-title">{{ title }}</h2>
+      <p class="modal-message">{{ message }}</p>
+      <div class="flex-row">
+          <button class="modal-confirm-btn" @click="confirmAction">{{ confirmMessage }}</button>
+        <button class="modal-cancel-btn" @click="cancelAction">{{ cancelMessage }}</button>
+      </div>
+    </div>
+  </div>
+</template>
+  
+<script setup lang="ts">
+import { ref, defineProps, defineEmits } from "vue";
+
+const props = defineProps({
+  title: String,
+  message: String,
+  confirmMessage: String,
+  cancelMessage: String,
+  isVisible: Boolean
+});
+
+const emit = defineEmits(["modal-dialogue-confirm", "modal-dialogue-cancel"]);
+
+// const isVisible = ref(false);
+
+const confirmAction = () => {
+//   isVisible.value = false;
+  emit("modal-dialogue-confirm");
+}
+
+const cancelAction = () => {
+//   isVisible.value = false;
+  emit("modal-dialogue-cancel");
+}
+</script>
+
+<style scoped>
+@import url("@/assets/css/confirm-dialogue-modal.css");
+</style>


### PR DESCRIPTION
## pull request 설명
쿠폰 관리 페이지에서 종료/삭제 버튼 눌러서 api 보냅니다.
삭제시, 조회페이지의 목록에서 제거해주는걸 추가 구현해주어야합니다. 다음번 merge에 적용하겠습니다.

![image](https://github.com/lotteon2/dailyon-admin-frontend/assets/109272333/bdc0b561-0d19-4522-9b56-00a491d5f211)

![image](https://github.com/lotteon2/dailyon-admin-frontend/assets/109272333/3afc8143-ca2c-4336-9b3d-b19efcc18d9f)

![image](https://github.com/lotteon2/dailyon-admin-frontend/assets/109272333/79ec342e-5f26-4719-8894-5a3b13a16c8a)


### 변경 사항

- [ ] fix bug
- [ ] add comment
- [x] add new feature
- [ ] update documents
- [ ] Improvement(refactoring and improving code)
- [ ] etc
